### PR TITLE
Fixes max size comparison

### DIFF
--- a/tiny_dng_loader.h
+++ b/tiny_dng_loader.h
@@ -5227,7 +5227,7 @@ bool LoadDNGFromMemory(const char* mem, unsigned int size,
             return false;
           }
 
-          const size_t dst_len = size_t(image->samples_per_pixel) * size_t(image->width) * size_t(image->rows_per_strip) *
+          const uint_64_ dst_len = size_t(image->samples_per_pixel) * size_t(image->width) * size_t(image->rows_per_strip) *
                size_t(image->bits_per_sample) / 8ull;
           if (dst_len == 0) {
             if (err) {
@@ -5240,7 +5240,7 @@ bool LoadDNGFromMemory(const char* mem, unsigned int size,
             return false;
           }
 
-          if ((1024ull * 1024ull * dst_len) > kMaxImageSizeInMB) {
+          if (dst_len > (kMaxImageSizeInMB * 1024ull * 1024ull)) {
             if (err) {
               (*err) += "Image data size too large. Exceeds " + std::to_string(kMaxImageSizeInMB) + " MB.\n";
             }


### PR DESCRIPTION
- left size is in Bytes, right size in MB, Fixing it so that each size is in bytes. dst_len = 242880 = 5 * 1024 *1024 = 5 mega bytes
kMaxImageSizeInMB= 64 giga bytes = 65535 mega bytes = 65535 * 1024 *1024 = 68718428160 bytes (previous code was putting that 5mb file as
dst_len = 242880 * 1024 *1024 = 254678138880 = 242 giga bytes)


- size_t usage needs some love for 32 bits platform (wasm for example) better use explicit 64 bits for images size in bytes